### PR TITLE
V1.2

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,12 @@ class DashApp:
     def serve_layout(self):
         # Process container data for visualization
         child_nodes, parent_nodes, edges, containers, parent_names = self.data_processor.process_container_data()
+        
+        #print("PARENT NODES")
+        #print(json.dumps(parent_nodes, indent=2))
 
+        #print("CHILD NODES")
+        #print(json.dumps(child_nodes, indent=2))
         
         self.containers = containers
         self.parent_names = parent_names

--- a/app.py
+++ b/app.py
@@ -1,52 +1,66 @@
 from dash import Dash, Input, Output
 import dash_cytoscape as cyto
 from layout import create_layout
-from data_processing import process_container_data
+from data_processing import DataProcessor
 from utils import coalesce
 import json
 import sys
 
-# This is needed to use advanced layouts like cola, spread, etc
-cyto.load_extra_layouts()
+class DashApp:
+    def __init__(self, dev_mode=False):
+        cyto.load_extra_layouts() # This is needed to use advanced layouts like cola, spread, etc
+        self.dev_mode = dev_mode
+        self.app = Dash(__name__)
+        self.data_processor = DataProcessor(dev_mode=dev_mode) 
+        self.app.layout = self.serve_layout # Dynamically serve the layout to ensure fresh data on each load
+        self.register_callbacks()
 
-app = Dash(__name__)
+    def serve_layout(self):
+        # Process container data for visualization
+        child_nodes, parent_nodes, edges, containers, parent_names = self.data_processor.process_container_data()
 
-def serve_layout():
-    # Process container data for visualization
-    child_nodes, parent_nodes, edges, containers, parent_names = process_container_data()
+        
+        self.containers = containers
+        self.parent_names = parent_names
 
-    # Store these in the app’s server context
-    app.containers = containers
-    app.parent_names = parent_names
+        # Set up the app layout with the generated elements
+        return create_layout(elements=child_nodes + parent_nodes + edges)
 
-    # Set up the app layout with the generated elements
-    return create_layout(elements=child_nodes + parent_nodes + edges)
+    def register_callbacks(self):
+        @self.app.callback(Output('cytoscape-tapNodeData-json', 'children'), Input('cytoscape', 'tapNodeData'))
+        def displayTapNodeData(data):
+            if(data):
+                id = data.get('id')
+                if(id in self.parent_names):
+                    child_names = [c.get('name') for c in self.containers if c.get('stack') == id]
+                    return json.dumps({
+                        'Container Stack': id,
+                        'Container Count': len(child_names),
+                        'Container Names': child_names
+                    }, indent=2)
+                else:
+                    container = next((c for c in self.containers if c.get('name') == data.get('id')), None)
+                    return json.dumps(coalesce(container, data), indent=2)
+            else:
+                return "Click on a node to see additional details"
 
-# Dynamically serve the layout to ensure fresh data on each load
-app.layout = serve_layout
-
-@ app.callback(Output('cytoscape-tapNodeData-json', 'children'), Input('cytoscape', 'tapNodeData'))
-def displayTapNodeData(data):
-    if(data):
-        id = data.get('id')
-        if(id in app.parent_names):
-            child_names = [c.get('name') for c in app.containers if c.get('stack') == id]
-            return json.dumps({
-                'Container Stack': id,
-                'Container Count': len(child_names),
-                'Container Names': child_names
-            }, indent=2)
+    def run(self):
+        if self.dev_mode:
+            print("Running in development mode")
+            self.app.run(host="127.0.0.1", port=8050, debug=False)
         else:
-            container = next((c for c in app.containers if c.get('name') == data.get('id')), None)
-            return json.dumps(coalesce(container, data), indent=2)
-    else:
-        return "Click on a node to see additional details"
+            print("Running in normal mode")
+            self.app.run(host="0.0.0.0", port=8050, debug=False)
+    
+def main():
+    dev_mode = False
+    
+    if len(sys.argv) > 1 and sys.argv[1] == "dev":
+        dev_mode = True
+
+    dash_app = DashApp(dev_mode=dev_mode)
+    dash_app.run()
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1 and sys.argv[1] == "dev":
-        print("Running in development mode")
-        app.run(host="127.0.0.1", port=8050, debug=False)
-    else:
-        print("Running in normal mode")
-        app.run(host="0.0.0.0", port=8050, debug=False)
+    main()
     

--- a/data_processing.py
+++ b/data_processing.py
@@ -29,7 +29,8 @@ class DataProcessor:
         for doc in docs:
             devices = doc['host']['devices']
             for dev in devices:
-                id = dev['id']
+                # id = dev['id'] # Use container ID as our identifier (old)
+                id = dev['name'] # Use container Name (new) 
                 if id not in containers:
                     containers[id] = dev
                 else:

--- a/data_processing.py
+++ b/data_processing.py
@@ -6,7 +6,7 @@ from utils import make_node, make_edge, coalesce
 
 class DataProcessor:
     def __init__(self, dev_mode=False):
-        conn_str = "mongodb://localhost:27017/" if dev_mode else "mongodb://mongo:27017/"
+        conn_str = "mongodb://localhost:27017/" if dev_mode else "mongodb://docker_dash_mongo:27017/"
         self.client = MongoClient(conn_str)
         self.db = self.client["dashdb"]
         self.collection = self.db["snapshots"]

--- a/data_processing.py
+++ b/data_processing.py
@@ -1,68 +1,106 @@
 # data_processing.py
 import json
+from pymongo import MongoClient
+#from bson import json_util
 from utils import make_node, make_edge, coalesce
 
-def load_container_data():
-    """Load and return the container data from JSON."""
-    with open("data/dd.json", "r") as f:
-        return json.load(f)
+class DataProcessor:
+    def __init__(self, dev_mode=False):
+        conn_str = "mongodb://localhost:27017/" if dev_mode else "mongodb://mongo:27017/"
+        self.client = MongoClient(conn_str)
+        self.db = self.client["dashdb"]
+        self.collection = self.db["snapshots"]
 
-def process_container_data():
-    containers = load_container_data()
-    
-    parent_nodes = []
-    parent_names = []
-    child_nodes = []
-    child_names = []
-    edges = []
-    edge_ids = []
-    for container in containers:
-        name = container.get('name')
-        parent_name = container.get('stack')
-        connections = container.get('connections')
-        listen_ports = container.get('listen_ports')
+    def load_container_data_json(self):
+        """Load and return the container data from JSON."""
+        containers = []
+        with open("data/dd.json", "r") as f:
+            containers = json.load(f)
+        return containers
 
-        if(parent_name):
-            parent_node = make_node(id=parent_name, label=parent_name, classes='stacks')
-        
-        child_node = make_node(id=name, label=name, classes='graph-node docker-container', parent=parent_name if parent_name else None)
+    def load_container_data_mongo(self):
+        """Load and return the container data from MongoDB."""
+        containers = {}
 
-        if(parent_name and parent_name not in parent_names):
-            parent_names.append(parent_name)
-            parent_nodes.append(parent_node)
-        
-        child_nodes.append(child_node)
-        child_names.append(name)
-
-        for connection in connections:
-            foreign_device = connection.get('foreign_device')
-            local_port = int(connection.get('local_port'))
-            edge = None
-
-            # Container to ip address node connection processing
-            if(foreign_device is None or foreign_device.endswith(" (Gateway)")):
-                foreign_ip = connection.get('foreign_ip')
-                if(foreign_ip not in child_names):
-                    child_names.append(foreign_ip)
-                    child_node = make_node(id=foreign_ip, label=coalesce(foreign_device, foreign_ip), classes='graph-node foreign-ip')
-                    child_nodes.append(child_node)
-                
-                if (local_port in listen_ports):
-                    edge = make_edge(id=foreign_ip+name, source=foreign_ip, target=name) # Inbound connection (IP -> Container)
+        # Get documents from MongoDB sort by most recent
+        # Each document is a "snapshot" of the discovery script output at the time the script was ran, so we want most recent data first
+        docs = list(self.collection.find().sort("snapshot_time", -1))
+        print("Documents Found: " + str(len(docs)))
+        for doc in docs:
+            devices = doc['host']['devices']
+            for dev in devices:
+                id = dev['id']
+                if id not in containers:
+                    containers[id] = dev
                 else:
-                    edge = make_edge(id=foreign_ip+name, source=name, target=foreign_ip) # Outbound connection (Container -> IP)
+                    # Merge connections and ports
+                    containers[id]["connections"].extend(dev.get("connections", []))
+                    containers[id]["listen_ports"].extend(dev.get("listen_ports", []))
         
-            # Container to container connection processing
-            else:
-                if (local_port in listen_ports):
-                    edge = make_edge(id=foreign_device+name, source=foreign_device, target=name) # Inbound connection (Container -> Container)
-                else:
-                    edge = make_edge(id=name+foreign_device, source=name, target=foreign_device) # Outbound connection (Container -> Container)
+        for c in containers.values():
+            c["connections"] = [dict(t) for t in {tuple(sorted(d.items())) for d in c["connections"]}]
+            c["listen_ports"] = list(set(c["listen_ports"]))
+
+        #print(json.dumps(containers.values(), indent=2, default=json_util.default))
+        return list(containers.values())
+
+    def process_container_data(self):
+        # containers = self.load_container_data_json()
+        containers = self.load_container_data_mongo()
+        
+        parent_nodes = []
+        parent_names = []
+        child_nodes = []
+        child_names = []
+        edges = []
+        edge_ids = []
+        for container in containers:
+            name = container.get('name')
+            parent_name = container.get('stack')
+            connections = container.get('connections')
+            listen_ports = container.get('listen_ports')
+
+            if(parent_name):
+                parent_node = make_node(id=parent_name, label=parent_name, classes='stacks')
             
-            # Add the edge to the list of edges if it is not already present
-            if edge:
-                edge_id = edge.get('data').get('id')
-                if edge_id not in edge_ids:
-                    edge_ids.append(edge_id)
-                    edges.append(edge)
-    return child_nodes, parent_nodes, edges, containers, parent_names
+            child_node = make_node(id=name, label=name, classes='graph-node docker-container', parent=parent_name if parent_name else None)
+
+            if(parent_name and parent_name not in parent_names):
+                parent_names.append(parent_name)
+                parent_nodes.append(parent_node)
+            
+            child_nodes.append(child_node)
+            child_names.append(name)
+
+            for connection in connections:
+                foreign_device = connection.get('foreign_device')
+                local_port = int(connection.get('local_port'))
+                edge = None
+
+                # Container to ip address node connection processing
+                if(foreign_device is None or foreign_device.endswith(" (Gateway)")):
+                    foreign_ip = connection.get('foreign_ip')
+                    if(foreign_ip not in child_names):
+                        child_names.append(foreign_ip)
+                        child_node = make_node(id=foreign_ip, label=coalesce(foreign_device, foreign_ip), classes='graph-node foreign-ip')
+                        child_nodes.append(child_node)
+                    
+                    if (local_port in listen_ports):
+                        edge = make_edge(id=foreign_ip+name, source=foreign_ip, target=name) # Inbound connection (IP -> Container)
+                    else:
+                        edge = make_edge(id=foreign_ip+name, source=name, target=foreign_ip) # Outbound connection (Container -> IP)
+            
+                # Container to container connection processing
+                else:
+                    if (local_port in listen_ports):
+                        edge = make_edge(id=foreign_device+name, source=foreign_device, target=name) # Inbound connection (Container -> Container)
+                    else:
+                        edge = make_edge(id=name+foreign_device, source=name, target=foreign_device) # Outbound connection (Container -> Container)
+                
+                # Add the edge to the list of edges if it is not already present
+                if edge:
+                    edge_id = edge.get('data').get('id')
+                    if edge_id not in edge_ids:
+                        edge_ids.append(edge_id)
+                        edges.append(edge)
+        return child_nodes, parent_nodes, edges, containers, parent_names

--- a/dd.py
+++ b/dd.py
@@ -1,14 +1,17 @@
 import docker
 import json
 import subprocess
+from datetime import datetime, timezone
 
 NETSTAT_STATES = ["CLOSE_WAIT", "CLOSED", "ESTABLISHED", "FIN_WAIT_1", "FIN_WAIT_2", "LAST_ACK", "LISTEN", "SYN_RECEIVED", "SYN_SEND", "TIME_WAIT"]
 
 client = docker.from_env()
+info = client.info()
 containers = client.containers.list()
 networks = client.networks.list()
 client.close()
 
+host = {"name": info['Name'], "os": info['OperatingSystem'], "cpu": info['NCPU'], "ram": round(info['MemTotal'] / 1024 / 1024 / 1024, 2)}
 
 network_name_set = {}
 for network in networks:
@@ -116,4 +119,7 @@ for device in devices:
         connection.update({"foreign_device": foreign_device})
 
 # Dump the data out
-print(json.dumps(devices, indent=2))
+
+host['devices'] = devices
+snapshot_time = datetime.now(timezone.utc).isoformat()
+print(json.dumps({"snapshot_time": snapshot_time, "host": host}, indent=2))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,17 @@ volumes:
   mongo_data:
 
 services:  
-  docker-dash:
+  docker_dash_app:
     image: m-e-w.dev/docker-dash:latest
     build: .
-    container_name: docker-dash
+    container_name: docker_dash_app
     depends_on:
-      - mongo
+      - docker_dash_mongo
     networks:
       - monitoring
-  mongo:
+  docker_dash_mongo:
     image: mongo
-    container_name: mongo
+    container_name: docker_dash_mongo
     ports:
       - "127.0.0.1:27017:27017"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+networks:
+  monitoring:
+    name: monitoring
+    external: true
+
+volumes:
+  mongo_data:
+
+services:  
+  docker-dash:
+    image: m-e-w.dev/docker-dash:latest
+    build: .
+    container_name: docker-dash
+    depends_on:
+      - mongo
+    networks:
+      - monitoring
+  mongo:
+    image: mongo
+    container_name: mongo
+    ports:
+      - "127.0.0.1:27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - monitoring

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 dash_cytoscape==1.0.2
 docker==7.1.0
+pymongo==4.15.3


### PR DESCRIPTION
**Major Changes**
- dash app now loads data from mongodb by default instead of from a static json file. old code is still there but won't be maintained.
- data gathering script (dd.py) can now write to mongo by passing mongo at run (i.e. python dd.py mongo)
- there is a docker compose file now to start mongo and dash app containers (docker compose up --build -d). Note i already had a network that i was using / needed the dash app on hence the external: true in the compose file. Either make your docker network in advance or remove that line. 
- read_me to be updated (eventually) (maybe) (probably)
- obligatory; "it runs on my machine"