### PR TITLE
Install config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Makefile
 *.json
+*.yml
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ Visualize network activity between Docker containers on a host. docker-dash coll
    ```
 
 2. **(Recommended) Build and start via Docker Compose:**
-   - Ensure the external `monitoring` network exists:
+   - Copy `docker-compose.yml.example` to `docker-compose.yml`
      ```bash
-     docker network create monitoring
+     cp docker-compose.yml.example docker-compose.yml
      ```
    - Start all services:
      ```bash
      docker-compose up --build -d
      ```
-   - This will launch both the dashboard app and a MongoDB instance, interconnected on the `monitoring` network.
+   - This will launch both the dashboard app and a MongoDB instance, interconnected on the `docker_dash` network.
 
 3. **Create the python virtual environment:**  
 The command below will create a folder called `venvs` in the users home directory and will then create a new python virtual environment called `docker-dash` inside of it. 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,7 +1,6 @@
 networks:
   monitoring:
     name: monitoring
-    external: true
 
 volumes:
   mongo_data:
@@ -9,18 +8,22 @@ volumes:
 services:  
   docker_dash_app:
     image: m-e-w.dev/docker-dash:latest
-    build: .
     container_name: docker_dash_app
-    depends_on:
-      - docker_dash_mongo
     networks:
       - monitoring
+    ports:
+      - "127.0.0.1:8050:8050"
+    depends_on:
+      - docker_dash_mongo
+    build: .
+
   docker_dash_mongo:
     image: mongo
     container_name: docker_dash_mongo
-    ports:
-      - "127.0.0.1:27017:27017"
     volumes:
       - mongo_data:/data/db
     networks:
       - monitoring
+    ports:
+      - "127.0.0.1:27017:27017"
+

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,29 +1,28 @@
 networks:
-  monitoring:
-    name: monitoring
+  docker_dash:
+    name: docker_dash
 
 volumes:
   mongo_data:
 
-services:  
-  docker_dash_app:
-    image: m-e-w.dev/docker-dash:latest
-    container_name: docker_dash_app
-    networks:
-      - monitoring
-    ports:
-      - "127.0.0.1:8050:8050"
-    depends_on:
-      - docker_dash_mongo
-    build: .
-
+services:
   docker_dash_mongo:
     image: mongo
     container_name: docker_dash_mongo
     volumes:
       - mongo_data:/data/db
     networks:
-      - monitoring
+      - docker_dash
     ports:
-      - "127.0.0.1:27017:27017"
+      - "127.0.0.1:27017:27017"  
 
+  docker_dash_app:
+    image: m-e-w.dev/docker-dash:latest
+    container_name: docker_dash_app
+    networks:
+      - docker_dash
+    ports:
+      - "8050:8050"
+    depends_on:
+      - docker_dash_mongo
+    build: .


### PR DESCRIPTION
Tweaked the docker compose file and read_me to reflect a simpler out of the box setup

- No reliance on a permanent network called 'monitoring' anymore. Docker compose will now create/manage the network (one less step now)
- Docker dash app now publishes to 0.0.0.0:8050 so you can access it via http://{DOCKER_HOST_IP}:8050 -- This is more in-line with typical example docker compose files in public repos. 